### PR TITLE
Fix INCEDENTRELAY_CONFIG_FILE env var typo (with legacy fallback)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           - "3.12"
 
     env:
-      INCEDENTRELAY_CONFIG_FILE: ${{ github.workspace }}/tests/incidentrelay.test.conf
+      INCIDENTRELAY_CONFIG_FILE: ${{ github.workspace }}/tests/incidentrelay.test.conf
       PYTHONPATH: ${{ github.workspace }}
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
-ENV INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+ENV INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ENV INCIDENTRELAY_SERVICE=web
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ incidentrelay
 IncidentRelay reads the configuration file path from:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 Example:
 
 ```bash
-export INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+export INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ```
 
 For production, set the public URL used for generated links and callback URLs:
@@ -267,7 +267,7 @@ For RPM/systemd installations:
 
 ```bash
 sudo -u incidentrelay \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python \
   /var/www/incidentrelay/manage.py migrate
 ```
@@ -285,7 +285,7 @@ For RPM/systemd installations:
 
 ```bash
 sudo -u incidentrelay \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python \
   /var/www/incidentrelay/manage.py create-admin \
   --username admin \

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,32 @@
 import os
+import sys
 
 
-CONFIG_FILE = os.getenv("INCEDENTRELAY_CONFIG_FILE", "/etc/incidentrelay/incidentrelay.conf")
+# Preferred env var name. The old, mis-spelled name is kept as a fallback so
+# existing self-hosted installations (Docker, systemd, RPM) keep working until
+# operators migrate. A one-time warning is printed on startup if only the
+# legacy name is set.
+_CONFIG_ENV = "INCIDENTRELAY_CONFIG_FILE"
+_LEGACY_CONFIG_ENV = "INCEDENTRELAY_CONFIG_FILE"
+_DEFAULT_CONFIG_PATH = "/etc/incidentrelay/incidentrelay.conf"
+
+
+def _resolve_config_path():
+    """Return the configured config file path, preferring the non-typo env var."""
+    value = os.getenv(_CONFIG_ENV)
+    if value:
+        return value
+
+    legacy = os.getenv(_LEGACY_CONFIG_ENV)
+    if legacy:
+        print(
+            f"WARNING: environment variable {_LEGACY_CONFIG_ENV} is deprecated "
+            f"(typo); please use {_CONFIG_ENV} instead.",
+            file=sys.stderr,
+        )
+        return legacy
+
+    return _DEFAULT_CONFIG_PATH
+
+
+CONFIG_FILE = _resolve_config_path()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: incidentrelay
     restart: unless-stopped
     environment:
-      INCEDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
+      INCIDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
       INCIDENTRELAY_SERVICE: web
       INCIDENTRELAY_RUN_MIGRATIONS: "1"
       INCIDENTRELAY_PORT: "8080"
@@ -35,7 +35,7 @@ services:
     container_name: incidentrelay-scheduler
     restart: unless-stopped
     environment:
-      INCEDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
+      INCIDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
       INCIDENTRELAY_SERVICE: scheduler
       INCIDENTRELAY_RUN_MIGRATIONS: "0"
     volumes:
@@ -54,7 +54,7 @@ services:
     container_name: incidentrelay-telegram
     restart: unless-stopped
     environment:
-      INCEDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
+      INCIDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
       INCIDENTRELAY_SERVICE: telegram
       INCIDENTRELAY_RUN_MIGRATIONS: "0"
       PYTHONUNBUFFERED: "1"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONFIG_FILE="${INCEDENTRELAY_CONFIG_FILE:-/etc/incidentrelay/incidentrelay.conf}"
+# Prefer the correctly-spelled env var; fall back to the legacy mis-spelled
+# one so existing deployments keep working until operators migrate.
+if [ -n "${INCEDENTRELAY_CONFIG_FILE:-}" ] && [ -z "${INCIDENTRELAY_CONFIG_FILE:-}" ]; then
+  echo "WARNING: environment variable INCEDENTRELAY_CONFIG_FILE is deprecated (typo); please use INCIDENTRELAY_CONFIG_FILE instead." >&2
+fi
+CONFIG_FILE="${INCIDENTRELAY_CONFIG_FILE:-${INCEDENTRELAY_CONFIG_FILE:-/etc/incidentrelay/incidentrelay.conf}}"
 SERVICE="${INCIDENTRELAY_SERVICE:-web}"
 
 if [ ! -f "$CONFIG_FILE" ]; then

--- a/docs/administration/scheduler.md
+++ b/docs/administration/scheduler.md
@@ -56,7 +56,7 @@ Do not use a global runtime fallback for reminder-after when rotations require a
 The scheduler process should use:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 INCIDENTRELAY_SERVICE=scheduler
 PYTHONUNBUFFERED=1
 ```
@@ -64,7 +64,7 @@ PYTHONUNBUFFERED=1
 The web process should use:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 INCIDENTRELAY_SERVICE=web
 PYTHONUNBUFFERED=1
 ```
@@ -98,7 +98,7 @@ Type=simple
 User=www-data
 Group=www-data
 WorkingDirectory=/var/www/incidentrelay
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 Environment=INCIDENTRELAY_SERVICE=scheduler
 Environment=PYTHONUNBUFFERED=1
 ExecStart=/var/www/incidentrelay/venv/bin/python -m app.scheduler_worker

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -8,26 +8,26 @@ description: IncidentRelay configuration file reference
 IncidentRelay reads the config file path from:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 Example:
 
 ```bash
-export INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+export INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ```
 
 For systemd:
 
 ```ini
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ```
 
 For Docker Compose:
 
 ```yaml
 environment:
-  INCEDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
+  INCIDENTRELAY_CONFIG_FILE: /etc/incidentrelay/incidentrelay.conf
 ```
 
 The old `ONCALL_CONFIG_FILE` name should not be used.

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -43,7 +43,7 @@ Default config path inside the container:
 The config file is selected by:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 ## Quick start with SQLite

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -33,7 +33,7 @@ After installation:
 The config file is selected by:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 Use the exact name above. The older `ONCALL_CONFIG_FILE` name should not be used.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,7 +6,7 @@ Use this checklist after installation.
 
 - [ ] Installed with Docker, RPM, or manual systemd guide
 - [ ] Config file exists
-- [ ] `INCEDENTRELAY_CONFIG_FILE` points to the config file
+- [ ] `INCIDENTRELAY_CONFIG_FILE` points to the config file
 - [ ] Web service is running
 - [ ] Scheduler service is running
 - [ ] Migrations have been applied with `python manage.py migrate`

--- a/docs/getting-started/rpm-installation.md
+++ b/docs/getting-started/rpm-installation.md
@@ -101,7 +101,7 @@ The RPM package may run migrations during installation. If the database was not 
 
 ```bash
 sudo -u incidentrelay \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python \
   /var/www/incidentrelay/manage.py migrate
 ```
@@ -110,7 +110,7 @@ sudo -u incidentrelay \
 
 ```bash
 sudo -u incidentrelay \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python \
   /var/www/incidentrelay/manage.py create-admin \
     --username admin \
@@ -179,7 +179,7 @@ After upgrade, run migrations if needed:
 
 ```bash
 sudo -u incidentrelay \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python \
   /var/www/incidentrelay/manage.py migrate
 ```

--- a/docs/getting-started/systemd.md
+++ b/docs/getting-started/systemd.md
@@ -30,7 +30,7 @@ The scheduler must run as a separate service. Do not start it inside every web w
 IncidentRelay reads the configuration path from:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 The old `ONCALL_CONFIG_FILE` variable should not be used.
@@ -166,7 +166,7 @@ sudo systemctl daemon-reload
 ```bash
 cd /var/www/incidentrelay
 sudo -u www-data \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python app/migrate.py migrate
 ```
 
@@ -175,7 +175,7 @@ sudo -u www-data \
 ```bash
 cd /var/www/incidentrelay
 sudo -u www-data \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python manage.py create-admin \
     --username admin \
     --password 'change-me-123' \
@@ -243,7 +243,7 @@ Group=www-data
 
 WorkingDirectory=/var/www/incidentrelay
 
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 Environment=INCIDENTRELAY_SERVICE=web
 Environment=PYTHONUNBUFFERED=1
 
@@ -282,7 +282,7 @@ Group=www-data
 
 WorkingDirectory=/var/www/incidentrelay
 
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 Environment=INCIDENTRELAY_SERVICE=scheduler
 Environment=PYTHONUNBUFFERED=1
 
@@ -391,7 +391,7 @@ sudo git pull
 sudo /var/www/incidentrelay/venv/bin/pip install -r requirements.txt
 
 sudo -u www-data \
-  INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
+  INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf \
   /var/www/incidentrelay/venv/bin/python app/migrate.py migrate
 
 sudo systemctl start incidentrelay

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,13 +51,13 @@ Do not run scheduler jobs inside every web worker.
 IncidentRelay reads the config path from:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 Example:
 
 ```bash
-export INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+export INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ```
 
 The old `ONCALL_CONFIG_FILE` name should not be used.

--- a/docs/project-readme.md
+++ b/docs/project-readme.md
@@ -57,13 +57,13 @@ Telegram worker is optional and only needed when Telegram polling/actions are us
 IncidentRelay reads config path from:
 
 ```text
-INCEDENTRELAY_CONFIG_FILE
+INCIDENTRELAY_CONFIG_FILE
 ```
 
 Example:
 
 ```bash
-export INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+export INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 ```
 
 Do not use the old `ONCALL_CONFIG_FILE` name.

--- a/etc/systemd/incidentrelay-scheduler.service
+++ b/etc/systemd/incidentrelay-scheduler.service
@@ -11,7 +11,7 @@ Group=incidentrelay
 
 WorkingDirectory=/var/www/incidentrelay
 
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 Environment=INCIDENTRELAY_SERVICE=scheduler
 Environment=PYTHONUNBUFFERED=1
 

--- a/etc/systemd/incidentrelay-telegram-worker.service
+++ b/etc/systemd/incidentrelay-telegram-worker.service
@@ -8,7 +8,7 @@ User=incidentrelay
 Group=incidentrelay
 WorkingDirectory=/var/www/incidentrelay
 
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 Environment=PYTHONUNBUFFERED=1
 
 ExecStart=/usr/bin/python3 -m app.telegram_worker

--- a/etc/systemd/incidentrelay.service
+++ b/etc/systemd/incidentrelay.service
@@ -10,7 +10,7 @@ Group=incidentrelay
 
 WorkingDirectory=/var/www/incidentrelay
 
-Environment=INCEDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
+Environment=INCIDENTRELAY_CONFIG_FILE=/etc/incidentrelay/incidentrelay.conf
 
 ExecStart=/usr/local/bin/gunicorn \
     --workers 4 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_DB = ROOT_DIR / "tests" / ".tmp" / "incidentrelay-ci.db"
 TEST_CONFIG = ROOT_DIR / "tests" / "incidentrelay.test.conf"
 
 # Must be set before importing app.settings/app.db/app models.
-os.environ.setdefault("INCEDENTRELAY_CONFIG_FILE", str(TEST_CONFIG))
+os.environ.setdefault("INCIDENTRELAY_CONFIG_FILE", str(TEST_CONFIG))
 os.environ.setdefault("PYTHONPATH", str(ROOT_DIR))
 
 (ROOT_DIR / "tests" / ".tmp").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Rename the config-file env var from the mis-spelled `INCEDENTRELAY_CONFIG_FILE` to `INCIDENTRELAY_CONFIG_FILE` across Docker, docker-compose, systemd units, RPM/manual install docs, CI and tests (19 files).
- Both `app/config.py` and `docker/entrypoint.sh` keep reading the legacy name as a fallback and print a one-time deprecation warning to stderr — so existing self-hosted installations don't break.
- New installations and docs now use the correctly-spelled name from the start.

## Test plan

- [x] `python -m compileall app manage.py run.py tests/conftest.py` passes (same as CI syntax step).
- [x] `bash -n docker/entrypoint.sh` passes.
- [x] Manual functional test of `app/config.py._resolve_config_path()` covers four cases:
  - new var set → uses it, no warning;
  - only legacy var set → uses it, prints deprecation warning;
  - neither set → falls back to `/etc/incidentrelay/incidentrelay.conf`;
  - both set → new wins, no warning.
- [x] Same four cases verified for `docker/entrypoint.sh` resolver block.
- [ ] CI `Tests` workflow on this PR (Python 3.10 / 3.11 / 3.12).
- [ ] Smoke-test a Docker build with only the legacy env var set to confirm the warning is printed and the service still starts.

---

_This is an AI-assisted PR._