### PR TITLE
Add .gitignore for Python build artifacts and local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Byte-compiled / cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+venv/
+.venv/
+env/
+.env
+
+# Test artifacts
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+tests/.tmp/
+
+# Local runtime data
+logs/
+*.log
+*.sqlite
+*.sqlite3
+*.db
+
+# Local config (operators put real secrets here)
+incidentrelay.conf
+*.local.conf
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Build / packaging
+*.egg-info/
+build/
+dist/


### PR DESCRIPTION
## Summary

- The repository currently has no `.gitignore`, so local `__pycache__/`, virtualenvs, pytest/coverage caches, log files, SQLite databases under `tests/.tmp/` and operator-local `incidentrelay.conf` (with secrets) all show up in `git status` and risk being committed or copied into Docker images via `COPY . .`.
- Add a minimal `.gitignore` covering Python bytecode, venvs, pytest/coverage artifacts, runtime logs, local SQLite/config files, common IDE/editor noise and packaging output.
- Verified that no currently-tracked file matches the new patterns, so nothing disappears silently from `git status`.

## Test plan

- [x] `git ls-files | git check-ignore --stdin` returns no tracked files (i.e. the new ignore patterns don't mask anything already in the repo).
- [x] After running `python -m compileall app` and `pytest --collect-only`, `git status` shows only the `.gitignore` itself, not dozens of `__pycache__/` directories.
- [ ] CI `Tests` workflow still passes on this PR.

---

_This is an AI-assisted PR._