### PR TITLE
Fix alerts summary grid asset path

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -329,7 +329,7 @@
 <script src="/static/js/core/forms.js"></script>
 <script src="{{ url_for('static', filename='js/core/timezones.js') }}"></script>
 <script src="/static/js/sidebar.js"></script>
-<script src="/static/js/components/alerts_summary_grid.js"></script>
+<script src="{{ url_for('static', filename='js/components/alerts/alerts_summary_grid.js') }}"></script>
 <script src="/static/js/components/buttons.js"></script>
 <script src="/static/js/components/oncall_status_panel.js"></script>
 <script src="{{ url_for('static', filename='js/components/action_menu.js') }}"></script>


### PR DESCRIPTION
## What

Fixes the Alerts/Overview summary grid script include path in the main app shell.

The template was loading `/static/js/components/alerts_summary_grid.js`, but the actual file lives at `/static/js/components/alerts/alerts_summary_grid.js`. Because of that, the Alerts page could receive `/api/alerts` data successfully and still fail to render with `ReferenceError: renderAlertsSummaryGrid is not defined`.

## Verification

Rebuilt the local image and redeployed the Helm chart on kind. After the fix, the Alerts page renders the ingested Alertmanager alert and the browser console has no `renderAlertsSummaryGrid` error.
