### PR TITLE
Add Slack Socket Mode worker deployment to the Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Read more: [Docker installation](docs/getting-started/docker.md)
 
 ### Kubernetes (Helm)
 
-A Helm chart lives in `helm/incidentrelay`. It deploys the web UI plus the scheduler and Telegram workers, renders the application config from values into a Secret, and wires up the `/healthz` and `/readyz` probes.
+A Helm chart lives in `helm/incidentrelay`. It deploys the web UI plus the scheduler, Telegram and Slack workers, renders the application config from values into a Secret, and wires up the `/healthz` and `/readyz` probes.
 
 ```bash
 helm install incidentrelay ./helm/incidentrelay \

--- a/helm/incidentrelay/Chart.yaml
+++ b/helm/incidentrelay/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: incidentrelay
 description: On-call scheduling, alert routing and incident notification service
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.1.0"
 home: https://github.com/roxy-wi/IncidentRelay
 sources:

--- a/helm/incidentrelay/templates/NOTES.txt
+++ b/helm/incidentrelay/templates/NOTES.txt
@@ -4,6 +4,7 @@ Components:
   web        {{ .Values.web.replicaCount }} replica(s)
   scheduler  {{ .Values.scheduler.enabled | ternary "enabled" "disabled" }}
   telegram   {{ .Values.telegram.enabled | ternary "enabled" "disabled" }}
+  slack      {{ .Values.slack.enabled | ternary "enabled" "disabled" }}
 
 Access the web UI:
 {{- if .Values.ingress.enabled }}

--- a/helm/incidentrelay/templates/deployment-slack.yaml
+++ b/helm/incidentrelay/templates/deployment-slack.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.slack.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "incidentrelay.fullname" . }}-slack
+  labels:
+    {{- include "incidentrelay.labels" . | nindent 4 }}
+    app.kubernetes.io/component: slack
+spec:
+  replicas: 1
+  {{- with .Values.slack.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "incidentrelay.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: slack
+  template:
+    metadata:
+      annotations:
+        {{- include "incidentrelay.configChecksum" . | nindent 8 }}
+        {{- with .Values.slack.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "incidentrelay.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: slack
+        {{- with .Values.slack.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "incidentrelay.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: slack
+          image: {{ include "incidentrelay.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: INCIDENTRELAY_CONFIG_FILE
+              value: /etc/incidentrelay/incidentrelay.conf
+            - name: INCIDENTRELAY_SERVICE
+              value: slack
+            - name: INCIDENTRELAY_RUN_MIGRATIONS
+              value: "0"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            {{- with .Values.slack.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.slack.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- include "incidentrelay.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "incidentrelay.volumes" . | nindent 8 }}
+      {{- with .Values.slack.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.slack.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.slack.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/incidentrelay/values.yaml
+++ b/helm/incidentrelay/values.yaml
@@ -131,6 +131,20 @@ telegram:
   affinity: {}
   extraEnv: []
 
+# Socket Mode worker for Slack interactive buttons. Harmless without a
+# configured Slack app (it idles), disable it if you do not use Slack.
+slack:
+  enabled: true
+  strategy:
+    type: Recreate
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnv: []
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## Problem

`entrypoint.sh` has supported `INCIDENTRELAY_SERVICE=slack` since the worker was added, and `docker/docker-compose.yml` runs it as `incidentrelay-slack` — but the Helm chart never shipped a Deployment for it. The chart even renders `config.logging.slack_worker_file` into the config Secret, so the omission looks accidental.

Effect on Kubernetes: Slack interactive buttons were dead. The web pod posts messages through `chat.postMessage`, but nothing held the Socket Mode WebSocket, so Acknowledge and friends did nothing.

## Change

- `templates/deployment-slack.yaml` — mirrors the telegram worker (single replica, `Recreate`, no migrations, shared config/data/logs volumes)
- `values.yaml` — `slack` block, enabled by default like `telegram`; harmless without a configured Slack app, the worker idles
- `NOTES.txt` — slack line in the component list
- `README.md` — mention the worker

## Verification

Manually deployed on a kind cluster (k8s v1.36.1) from a locally built image:

- all four pods `1/1 Running`, 0 restarts; `/healthz` and `/readyz` return 200 to kube-probe, also through the Service
- after configuring a Slack channel in the UI (Bot API → Socket Mode), the worker picked up the config straight from the database with no pod restart: `Slack Socket Mode connection started`, `channel_count: 1`
- an alert delivered through a webhook route reached Slack, and **Acknowledge** from Slack updated the alert status in the UI — the path that did not work on Kubernetes before this change
- `helm lint` clean; `--set slack.enabled=false` removes the Deployment
- full pytest suite: 1219 passed (unaffected — no Python changed)