### PR TITLE
Fix SSO group mapping edit modal

### DIFF
--- a/app/static/js/pages/sso.js
+++ b/app/static/js/pages/sso.js
@@ -766,8 +766,8 @@ function openExistingSsoMappingModal(mapping) {
   $("#sso-mapping-external-group").val(mapping.external_group || "");
   fillSsoGroupSelect(mapping.group_id);
   fillSsoTeamSelect(mapping.team_id);
-  $("#sso-mapping-role").valssoRoleLabel(mapping.group_role || "viewer", "group");
-  $("#sso-mapping-team-role").valssoRoleLabel(mapping.team_role || "viewer", "team");
+  $("#sso-mapping-role").val(mapping.group_role || "viewer");
+  $("#sso-mapping-team-role").val(mapping.team_role || "viewer");
   $("#sso-mapping-team-role").prop("disabled", !mapping.team_id);
   $("#sso-mapping-priority").val(mapping.priority || 100);
   $("#sso-mapping-active").prop("checked", !!mapping.active);

--- a/tests/test_sso.py
+++ b/tests/test_sso.py
@@ -26,6 +26,7 @@ from app.views.sso_admin_view import (
     delete_provider,
     list_group_mappings,
     list_providers,
+    update_group_mapping,
     update_provider,
 )
 from app.views.sso_auth_view import (
@@ -33,7 +34,7 @@ from app.views.sso_auth_view import (
     _validate_oidc_id_token,
     public_sso_providers,
 )
-from tests.factories import create_group, create_user, unique
+from tests.factories import create_group, create_team, create_user, unique
 from app.api.schemas.limits import normalize_phone
 
 
@@ -308,6 +309,137 @@ def test_admin_can_list_sso_group_mappings(app):
     assert len(data) == 1
     assert data[0]["external_group"] == "noc-sso"
     assert data[0]["group_role"] == "viewer"
+
+
+def test_admin_can_update_sso_group_mapping(app):
+    admin = make_admin()
+    provider = make_oidc_provider(slug="update-mapping-provider")
+    group = create_group(slug="sre", name="SRE")
+    team = create_team(group, slug="sre-oncall", name="SRE On-call")
+
+    mapping = SsoGroupMapping.create(
+        provider=provider,
+        external_group="sre-sso",
+        incidentrelay_group=group,
+        group_role="viewer",
+        active=True,
+        priority=100,
+    )
+
+    with app.test_request_context(
+        f"/api/admin/sso/mappings/{mapping.id}",
+        method="PUT",
+        json={
+            "external_group": "sre-sso-renamed",
+            "group_id": group.id,
+            "group_role": "editor",
+            "team_id": team.id,
+            "team_role": "manager",
+            "active": False,
+            "priority": 5,
+        },
+    ):
+        from flask import request
+
+        request.current_user = admin
+        response = update_group_mapping(mapping.id)
+
+    data = response.get_json()
+    mapping = SsoGroupMapping.get_by_id(mapping.id)
+
+    assert data["external_group"] == "sre-sso-renamed"
+    assert data["group_role"] == "editor"
+    assert data["team_id"] == team.id
+    assert data["team_role"] == "manager"
+    assert data["active"] is False
+    assert data["priority"] == 5
+    assert mapping.external_group == "sre-sso-renamed"
+    assert mapping.incidentrelay_team.id == team.id
+    assert mapping.active is False
+
+
+def test_admin_can_detach_team_from_sso_group_mapping(app):
+    admin = make_admin()
+    provider = make_oidc_provider(slug="detach-team-mapping-provider")
+    group = create_group(slug="net", name="Network")
+    team = create_team(group, slug="net-core", name="Core Network")
+
+    mapping = SsoGroupMapping.create(
+        provider=provider,
+        external_group="net-sso",
+        incidentrelay_group=group,
+        group_role="editor",
+        incidentrelay_team=team,
+        team_role="responder",
+        active=True,
+        priority=20,
+    )
+
+    with app.test_request_context(
+        f"/api/admin/sso/mappings/{mapping.id}",
+        method="PUT",
+        json={
+            "external_group": "net-sso",
+            "group_id": group.id,
+            "group_role": "editor",
+            "team_id": None,
+            "active": True,
+            "priority": 20,
+        },
+    ):
+        from flask import request
+
+        request.current_user = admin
+        response = update_group_mapping(mapping.id)
+
+    data = response.get_json()
+    mapping = SsoGroupMapping.get_by_id(mapping.id)
+
+    assert data["team_id"] is None
+    assert data["team_role"] is None
+    assert mapping.incidentrelay_team_id is None
+    assert mapping.team_role is None
+
+
+def test_admin_cannot_map_team_from_another_group(app):
+    admin = make_admin()
+    provider = make_oidc_provider(slug="foreign-team-mapping-provider")
+    group = create_group(slug="dba", name="DBA")
+    other_group = create_group(slug="qa", name="QA")
+    other_team = create_team(other_group, slug="qa-web", name="QA Web")
+
+    mapping = SsoGroupMapping.create(
+        provider=provider,
+        external_group="dba-sso",
+        incidentrelay_group=group,
+        group_role="viewer",
+        active=True,
+        priority=100,
+    )
+
+    with app.test_request_context(
+        f"/api/admin/sso/mappings/{mapping.id}",
+        method="PUT",
+        json={
+            "external_group": "dba-sso",
+            "group_id": group.id,
+            "group_role": "viewer",
+            "team_id": other_team.id,
+            "team_role": "manager",
+            "active": True,
+            "priority": 100,
+        },
+    ):
+        from flask import request
+
+        request.current_user = admin
+        response, status = update_group_mapping(mapping.id)
+
+    mapping = SsoGroupMapping.get_by_id(mapping.id)
+
+    assert status == 400
+    assert response.get_json()["error"] == "validation_error"
+    assert mapping.incidentrelay_team_id is None
 
 
 def test_non_admin_cannot_manage_sso(app):


### PR DESCRIPTION
Fixes #42

## Problem

`openExistingSsoMappingModal()` in `app/static/js/pages/sso.js` called `.valssoRoleLabel(...)` on the two role selects — `.val(` and `ssoRoleLabel(` had been mashed into a single non-existent jQuery method:

```js
$("#sso-mapping-role").valssoRoleLabel(mapping.group_role || "viewer", "group");
$("#sso-mapping-team-role").valssoRoleLabel(mapping.team_role || "viewer", "team");
```

Clicking **Edit** on a mapping threw `TypeError: $(...).valssoRoleLabel is not a function` before reaching `openAppModal("#sso-mapping-modal")`, so the modal never opened and mapping rules could only be deleted and re-created.

Note that `ssoRoleLabel()` returns a translated display label (`"Group Admin"`), not an option value (`"user_admin"`), so it was the wrong helper here even apart from the syntax error.

The backend (`PUT /api/admin/sso/mappings/<id>`, `sso_repo.update_group_mapping()`) and `saveSsoMapping()` were already correct — this was purely the form-prefill step.

Present on both `main` (1.2, the version reported in the issue) and `release/2.0`.

## Fix

```js
$("#sso-mapping-role").val(mapping.group_role || "viewer");
$("#sso-mapping-team-role").val(mapping.team_role || "viewer");
```

## Tests

`PUT /api/admin/sso/mappings/<id>` had no coverage at all (only create/list/soft-delete were tested). Added three cases:

- `test_admin_can_update_sso_group_mapping` — full update including team attach
- `test_admin_can_detach_team_from_sso_group_mapping` — `team_id: null` also clears `team_role`
- `test_admin_cannot_map_team_from_another_group` — 400 `validation_error`, mapping left unchanged

Full suite: 1493 passed.

## Manual verification

Ran locally against a fresh SQLite database, following the reproduction steps from the issue:

1. Created an OIDC provider
2. Created a mapping — `infra-sso` → Infrastructure / Group Admin / Infra On-call / Team Manager / priority 42
3. Clicked **Edit** — the modal now opens with every field prefilled correctly (`group_role: user_admin`, `team_role: manager`, `priority: 42`, team-role select enabled)
4. Changed the values and saved — persisted via `PUT`, `id` unchanged and `updated_at` bumped, i.e. an actual edit rather than a re-create

Also confirmed the inverse: with the pre-fix function in place, clicking **Edit** does nothing, the action menu does not even close, and the console shows `TypeError: $(...).valssoRoleLabel is not a function`.