### PR TITLE
Fix: remove redundant slashes in static CSS paths

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,7 +22,7 @@
     };
     </script>
     <script src="{{ url_for('static', filename='js/core/theme.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='/css/vendor/fontawesome/all.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/fontawesome/all.min.css') }}">
     <link rel="stylesheet" href="/static/css/oncall.css">
     <link rel="stylesheet" href="/static/css/material.css">
     <link rel="stylesheet" href="/static/css/table_pages.css">
@@ -47,7 +47,7 @@
     <script src="{{ url_for('static', filename='js/vendor/tom-select.complete.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/vendor/chart.min.js') }}"></script>
     <script>window.AppTheme && window.AppTheme.applyChartDefaults();</script>
-    <script src="{{ url_for('static', filename='/js/vendor/cytoscape.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/vendor/cytoscape.min.js') }}"></script>
 </head>
 <body class="md-theme">
 <section class="layout">

--- a/app/templates/login_only.html
+++ b/app/templates/login_only.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="/static/css/oncall.css">
     <link rel="stylesheet" href="/static/css/material.css">
     <link rel="stylesheet" href="/static/css/theme_dark.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='/css/vendor/fontawesome/all.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/vendor/fontawesome/all.min.css') }}">
     <script>
  window.__INCIDENTRELAY_I18N__ = {
   locale: {{ current_locale | tojson }},


### PR DESCRIPTION
- Changed "/css/..." to "css/..." for correct url_for usage over HTTPS via nginx

CSS and FontAwesome files return 308 errors behind HTTPS proxy (NGINX) due to leading slashes in static paths.